### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/325/91/85632591.geojson
+++ b/data/856/325/91/85632591.geojson
@@ -977,6 +977,10 @@
     },
     "wof:country":"SB",
     "wof:country_alpha3":"SLB",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"c93cb07aa19ae55e490a5113a90853b7",
     "wof:hierarchy":[
         {
@@ -991,7 +995,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638661,
+    "wof:lastmodified":1582319032,
     "wof:name":"Solomon Islands",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/770/77/85677077.geojson
+++ b/data/856/770/77/85677077.geojson
@@ -266,6 +266,9 @@
         "wk:page":"Malaita Province"
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"becd5d3e06850598794886168e8ae1a8",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638660,
+    "wof:lastmodified":1582319031,
     "wof:name":"Malaita",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/85/85677085.geojson
+++ b/data/856/770/85/85677085.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Central Province (Solomon Islands)"
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"342d0bf35283fcc4f565266bd1addf51",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638661,
+    "wof:lastmodified":1582319031,
     "wof:name":"Central",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/99/85677099.geojson
+++ b/data/856/770/99/85677099.geojson
@@ -260,6 +260,9 @@
         "wk:page":"Temotu Province"
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06b30903b9c7bc3746f1bfda40f7079c",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638660,
+    "wof:lastmodified":1582319031,
     "wof:name":"Temotu",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/03/85677103.geojson
+++ b/data/856/771/03/85677103.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Western Province (Solomon Islands)"
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a00ee1cdf03ecc56d84f9e95f9a3b75e",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638659,
+    "wof:lastmodified":1582319031,
     "wof:name":"Western",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/09/85677109.geojson
+++ b/data/856/771/09/85677109.geojson
@@ -210,6 +210,9 @@
         "wk:page":"Makira-Ulawa Province"
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f499022bafa5de5e794a3a04728885b",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638659,
+    "wof:lastmodified":1582319031,
     "wof:name":"Makira",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/857/681/75/85768175.geojson
+++ b/data/857/681/75/85768175.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":898564
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3be4a2a789afe96f5f12b22712dd9482",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566638659,
+    "wof:lastmodified":1582319031,
     "wof:name":"Niumara",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/358/09/85935809.geojson
+++ b/data/859/358/09/85935809.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1167844
     },
     "wof:country":"SB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8fc73328c779f9a1c2eef862b3092a0b",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566638658,
+    "wof:lastmodified":1582319031,
     "wof:name":"Tavioa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/428/963/890428963.geojson
+++ b/data/890/428/963/890428963.geojson
@@ -262,6 +262,9 @@
     },
     "wof:country":"SB",
     "wof:created":1469051784,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2da9f6102c3e216b7c5468a9c28c7c10",
     "wof:hierarchy":[
         {
@@ -272,7 +275,7 @@
         }
     ],
     "wof:id":890428963,
-    "wof:lastmodified":1566638839,
+    "wof:lastmodified":1582319036,
     "wof:name":"Lata",
     "wof:parent_id":85677099,
     "wof:placetype":"locality",

--- a/data/890/444/217/890444217.geojson
+++ b/data/890/444/217/890444217.geojson
@@ -457,6 +457,9 @@
     },
     "wof:country":"SB",
     "wof:created":1469052460,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"fb44964eb122983bc2736bf3853c3d4b",
     "wof:hierarchy":[
         {
@@ -465,7 +468,7 @@
         }
     ],
     "wof:id":890444217,
-    "wof:lastmodified":1566638839,
+    "wof:lastmodified":1582319036,
     "wof:name":"Honiara",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.