### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/721/3/1141907213.geojson
+++ b/data/114/190/721/3/1141907213.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_variant":[
         "\u0644\u0627\u062a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u062a\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09a4\u09be"
     ],
@@ -127,7 +130,7 @@
         "\u0bb2\u0b9f\u0bbe"
     ],
     "name:tam_x_variant":[
-        "\u0bb2\u0b9f\u0bbe"
+        "\u0bb2\u0b9f\u0bbe "
     ],
     "name:tel_x_preferred":[
         "\u0c32\u0c24\u0c3e"
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":1141907213,
-    "wof:lastmodified":1636495728,
+    "wof:lastmodified":1690860394,
     "wof:name":"Lata",
     "wof:parent_id":85677099,
     "wof:placetype":"locality",

--- a/data/421/178/149/421178149.geojson
+++ b/data/421/178/149/421178149.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0643\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0643\u0649"
+    ],
+    "name:cat_x_preferred":[
+        "Auki"
+    ],
     "name:ceb_x_preferred":[
         "Auki"
     ],
@@ -43,6 +49,9 @@
     ],
     "name:glg_x_preferred":[
         "Auki"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d0\u05d5\u05e7\u05d9"
     ],
     "name:hrv_x_preferred":[
         "Auki"
@@ -75,6 +84,9 @@
         "Auki"
     ],
     "name:spa_x_preferred":[
+        "Auki"
+    ],
+    "name:swe_x_preferred":[
         "Auki"
     ],
     "name:ukr_x_preferred":[
@@ -138,7 +150,7 @@
         }
     ],
     "wof:id":421178149,
-    "wof:lastmodified":1566638838,
+    "wof:lastmodified":1690860392,
     "wof:name":"Auki",
     "wof:parent_id":85677077,
     "wof:placetype":"locality",

--- a/data/421/188/873/421188873.geojson
+++ b/data/421/188/873/421188873.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ces_x_preferred":[
+        "Kukumbona"
+    ],
     "name:dan_x_preferred":[
         "Kokumbona"
     ],
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421188873,
-    "wof:lastmodified":1566638838,
+    "wof:lastmodified":1690860392,
     "wof:name":"Kakambona",
     "wof:parent_id":85677089,
     "wof:placetype":"locality",

--- a/data/421/200/133/421200133.geojson
+++ b/data/421/200/133/421200133.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Kirakira"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u0438\u0440\u0430\u043a\u0438\u0440\u0430"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:glg_x_preferred":[
         "Kirakira"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d9\u05e8\u05d0\u05e7\u05d9\u05e8\u05d4"
     ],
     "name:hrv_x_preferred":[
         "Kirakira"
@@ -68,8 +74,14 @@
     "name:por_x_preferred":[
         "Kirakira"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0438\u0440\u0430\u043a\u0438\u0440\u0430"
+    ],
     "name:spa_x_preferred":[
         "Kirakira"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0456\u0440\u0430\u043a\u0456\u0440\u0430"
     ],
     "name:urd_x_preferred":[
         "\u06a9\u06cc\u0631\u0627\u06a9\u06cc\u0631\u0627"
@@ -126,7 +138,7 @@
         }
     ],
     "wof:id":421200133,
-    "wof:lastmodified":1566638838,
+    "wof:lastmodified":1690860392,
     "wof:name":"Kirakira",
     "wof:parent_id":85677109,
     "wof:placetype":"locality",

--- a/data/856/325/91/85632591.geojson
+++ b/data/856/325/91/85632591.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":8.0,
     "mz:min_zoom":3.0,
+    "name:abk_x_preferred":[
+        "\u0421\u043e\u043b\u043e\u043c\u043e\u043d \u0438\u0434\u0433\u044c\u044b\u043b\u0431\u0436\u044c\u0430\u0445\u0430\u049b\u04d9\u0430"
+    ],
     "name:ace_x_preferred":[
         "Pulo-pulo Solomon"
     ],
@@ -50,8 +53,14 @@
     "name:amh_x_variant":[
         "\u1230\u120e\u121e\u1295 \u12f0\u1234\u1275"
     ],
+    "name:ami_x_preferred":[
+        "Solomon"
+    ],
     "name:ang_x_preferred":[
         "Salomon \u012aege"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u094b\u0932\u094b\u092e\u0928 \u0926\u094d\u0935\u0940\u092a"
     ],
     "name:ara_x_preferred":[
         "\u062c\u0632\u0631 \u0633\u0644\u064a\u0645\u0627\u0646"
@@ -67,6 +76,9 @@
     ],
     "name:ast_x_preferred":[
         "Islles Salom\u00f3n"
+    ],
+    "name:avk_x_preferred":[
+        "Solomona"
     ],
     "name:azb_x_preferred":[
         "\u0633\u0648\u0644\u06cc\u0645\u0627\u0646 \u0622\u062f\u0627\u0644\u0627\u0631\u06cc"
@@ -94,6 +106,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09b2\u09cb\u09ae\u09a8 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
+    ],
+    "name:bis_x_preferred":[
+        "Solomon Aelan"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f7c\u0f0b\u0f63\u0f7c\u0f0b\u0f58\u0f7c\u0f53\u0f0b\u0f42\u0fb3\u0f72\u0f44\u0f0b\u0f55\u0fb2\u0f53\u0f0b\u0f5a\u0f7c\u0f0b\u0f41\u0f42"
@@ -145,8 +160,14 @@
     "name:che_x_preferred":[
         "\u0421\u043e\u043b\u043e\u043c\u043e\u043d\u0430\u043d \u0433\u04c0\u0430\u0439\u0440\u0435\u043d\u0430\u0448"
     ],
+    "name:chr_x_preferred":[
+        "\u13d0\u13b6\u13b9\u13c2 \u13da\u13a6\u13da\u13db\u13a2"
+    ],
     "name:chv_x_preferred":[
         "\u0421\u043e\u043b\u043e\u043c\u043e\u043d \u0423\u0442\u0440\u0430\u0432\u0115\u0441\u0435\u043c"
+    ],
+    "name:chy_x_preferred":[
+        "Solomon Islands"
     ],
     "name:ckb_x_preferred":[
         "\u062f\u0648\u0648\u0631\u06af\u06d5\u06a9\u0627\u0646\u06cc \u0633\u0644\u06ce\u0645\u0627\u0646"
@@ -154,11 +175,17 @@
     "name:cor_x_preferred":[
         "Ynysow Salamon"
     ],
+    "name:cos_x_preferred":[
+        "Xalomonu"
+    ],
     "name:crh_x_preferred":[
         "Solomon Adalar\u0131"
     ],
     "name:cym_x_preferred":[
         "Ynysoedd Solomon"
+    ],
+    "name:dag_x_preferred":[
+        "Solomon Islands"
     ],
     "name:dan_x_colloquial":[
         "Salomonoerne"
@@ -307,6 +334,9 @@
     "name:gom_x_preferred":[
         "\u0938\u094b\u0932\u094b\u092e\u0928 \u0926\u094d\u0935\u0940\u092a\u0938\u092e\u0942\u0939"
     ],
+    "name:gpe_x_preferred":[
+        "Solomon Islands"
+    ],
     "name:grn_x_preferred":[
         "Ypa'\u0169ngu\u00e9ra Salom\u00f5"
     ],
@@ -324,6 +354,9 @@
     ],
     "name:hau_x_preferred":[
         "Tsibiran Salaman"
+    ],
+    "name:hau_x_variant":[
+        "Tsibiran Solomon"
     ],
     "name:hbs_x_preferred":[
         "Solomonski Otoci"
@@ -363,6 +396,9 @@
         "\u054d\u0578\u056c\u0578\u0574\u0578\u0576\u0575\u0561\u0576 \u056f\u0572\u0566\u056b\u0576\u0565\u0580",
         "\u054d\u0578\u0572\u0578\u0574\u0578\u0576\u0575\u0561\u0576 \u056f\u0572\u0566\u056b\u0576\u0565\u0580"
     ],
+    "name:hyw_x_preferred":[
+        "\u054d\u0578\u0572\u0578\u0574\u0578\u0576\u0565\u0561\u0576 \u053f\u0572\u0566\u056b\u0576\u0565\u0580"
+    ],
     "name:ido_x_preferred":[
         "Insuli Salomon"
     ],
@@ -371,6 +407,9 @@
     ],
     "name:ina_x_preferred":[
         "Insulas Solomon"
+    ],
+    "name:ina_x_variant":[
+        "Insulas Salomon"
     ],
     "name:ind_x_preferred":[
         "Kepulauan Solomon"
@@ -394,6 +433,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30bd\u30ed\u30e2\u30f3\u8af8\u5cf6"
+    ],
+    "name:kaa_x_preferred":[
+        "Solomon Atawlar\u0131"
     ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cbe\u0cb2\u0cca\u0cae\u0ca8\u0ccd \u0ca6\u0ccd\u0cb5\u0cc0\u0caa\u0c97\u0cb3\u0cc1"
@@ -425,6 +467,9 @@
     "name:kor_x_variant":[
         "\uc194\ub85c\ubaac",
         "\uc194\ub85c\ubaac\uc81c\ub3c4"
+    ],
+    "name:krj_x_preferred":[
+        "Kasalomunan"
     ],
     "name:ksh_x_preferred":[
         "Salomone"
@@ -462,6 +507,9 @@
     "name:lit_x_variant":[
         "Saliamono salos"
     ],
+    "name:lld_x_preferred":[
+        "Ijules Salomon"
+    ],
     "name:lmo_x_preferred":[
         "Isul Salomon"
     ],
@@ -477,6 +525,9 @@
     "name:lzh_x_preferred":[
         "\u7d22\u7f85\u9580\u7fa4\u5cf6"
     ],
+    "name:lzh_x_variant":[
+        "\u6240\u7f85\u9580\u7fa4\u5cf6"
+    ],
     "name:mal_x_preferred":[
         "\u0d38\u0d4b\u0d33\u0d2e\u0d7b \u0d26\u0d4d\u0d35\u0d40\u0d2a\u0d41\u0d15\u0d7e"
     ],
@@ -488,6 +539,12 @@
     ],
     "name:mar_x_variant":[
         "\u0938\u094b\u0932\u094b\u092e\u0928 \u092c\u0947\u091f\u0947"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0421\u043e\u043b\u043e\u043c\u043e\u043d \u041e\u0442\u0440\u043e-\u0432\u043b\u0430\u043a"
+    ],
+    "name:min_x_preferred":[
+        "Kapulauan Salomon"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u043e\u043b\u043e\u043c\u043e\u043d\u0438"
@@ -506,6 +563,12 @@
     ],
     "name:mlt_x_variant":[
         "Solomon Islands"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe3\uabc2\uabe3\uabc3\uabe3\uabdf \uabcf\uabca\uabe0\uabc1\uabe4\uabe1"
+    ],
+    "name:mri_x_preferred":[
+        "Ng\u0101 Motu Horomona"
     ],
     "name:mrj_x_preferred":[
         "\u0421\u043e\u043b\u043e\u043c\u043e\u043d \u043e\u0448\u043c\u0430\u043e\u0442\u044b\u0432\u043b\u04d3"
@@ -533,6 +596,9 @@
     ],
     "name:nav_x_preferred":[
         "S\u00f3lomon T\u00f3 Bin\u00e1haazy\u00edn\u00edg\u00ed\u00ed"
+    ],
+    "name:nav_x_variant":[
+        "T\u00e1\u0142k\u00e1\u00e1\u02bc \u0141izhinii Bik\u00e9yah"
     ],
     "name:nde_x_preferred":[
         "Solomon Islands"
@@ -668,6 +734,9 @@
     "name:sgs_x_preferred":[
         "Saliamuona Salas"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u1030\u1087\u1075\u102f\u107c\u103a \u101e\u1031\u1083\u1087\u101c\u1031\u1083\u1087\u1019\u107c\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc3\u0ddc\u0dbd\u0db8\u0db1\u0dca \u0daf\u0dd4\u0db4\u0dad\u0dca"
     ],
@@ -687,11 +756,17 @@
     "name:sme_x_variant":[
         "Salomon-sullot"
     ],
+    "name:smn_x_preferred":[
+        "Salomonsuolluuh"
+    ],
     "name:smo_x_preferred":[
         "Le Motu o Solomona"
     ],
     "name:smo_x_variant":[
         "Solomon Islands"
+    ],
+    "name:sms_x_preferred":[
+        "Salomoon-su\u00f5llu"
     ],
     "name:sna_x_preferred":[
         "Solomon Islands"
@@ -787,6 +862,9 @@
     "name:ton_x_preferred":[
         "\u02bbOtumotu Solomone"
     ],
+    "name:ton_x_variant":[
+        "\u02bbOtu motu Solomone"
+    ],
     "name:tpi_x_preferred":[
         "Solomon Ailans"
     ],
@@ -795,6 +873,9 @@
     ],
     "name:tur_x_preferred":[
         "Solomon Adalar\u0131"
+    ],
+    "name:udm_x_preferred":[
+        "\u0421\u043e\u043b\u043e\u043c\u043e\u043d \u0448\u043e\u0440\u043c\u0443\u04f5\u044a\u0451\u0441"
     ],
     "name:uig_x_preferred":[
         "\u0633\u0648\u0644\u0648\u0645\u0648\u0646 \u062a\u0627\u0642\u0649\u0645 \u0626\u0627\u0631\u0627\u0644\u0644\u0649\u0631\u0649"
@@ -819,6 +900,9 @@
     ],
     "name:uzb_x_preferred":[
         "Solomon Orollari"
+    ],
+    "name:vec_x_preferred":[
+        "Sa\u0142omon"
     ],
     "name:vep_x_preferred":[
         "Solomonan Sared"
@@ -1113,7 +1197,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827413,
+    "wof:lastmodified":1690860390,
     "wof:name":"Solomon Islands",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/770/77/85677077.geojson
+++ b/data/856/770/77/85677077.geojson
@@ -35,8 +35,14 @@
     "name:ben_x_preferred":[
         "\u09ae\u09cd\u09af\u09be\u09b2\u09be\u0987\u099f\u09be \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:cat_x_preferred":[
+        "Malaita"
+    ],
     "name:ceb_x_preferred":[
         "Malaita Province"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Malaita"
     ],
     "name:dan_x_preferred":[
         "Malaita Province"
@@ -65,17 +71,26 @@
     "name:fra_x_variant":[
         "province de Malaita"
     ],
+    "name:frr_x_preferred":[
+        "Malaita"
+    ],
     "name:glg_x_preferred":[
         "Malaita"
     ],
     "name:guj_x_preferred":[
         "\u0aae\u0ab2\u0abe\u0a88\u0aa4\u0abe \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05de\u05d0\u05dc\u05d0\u05d9\u05d0\u05d9\u05d8\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u0932\u093e\u0907\u091f\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
     "name:hrv_x_preferred":[
         "Malaita"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0544\u0561\u056c\u0565\u0569\u0561 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Malaita"
@@ -106,6 +121,9 @@
     ],
     "name:msa_x_preferred":[
         "Wilayah Malaita"
+    ],
+    "name:nan_x_preferred":[
+        "Malaita S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Malaita"
@@ -287,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495725,
+    "wof:lastmodified":1690860389,
     "wof:name":"Malaita",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/81/85677081.geojson
+++ b/data/856/770/81/85677081.geojson
@@ -55,6 +55,9 @@
     "name:eng_x_variant":[
         "Rennell and Bellona Province"
     ],
+    "name:eus_x_preferred":[
+        "Rennell eta Bellonako probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0631\u0646\u0627\u0644 \u0648 \u0628\u0644\u0648\u0646\u0627"
     ],
@@ -63,6 +66,9 @@
     ],
     "name:fra_x_preferred":[
         "Province de Rennell et Bellona"
+    ],
+    "name:frr_x_preferred":[
+        "Rennell an Bellona"
     ],
     "name:glg_x_preferred":[
         "Rennell e Bellona"
@@ -73,6 +79,9 @@
     "name:heb_x_preferred":[
         "\u05e8\u05e0\u05dc \u05d5\u05d1\u05dc\u05d5\u05e0\u05d4"
     ],
+    "name:heb_x_variant":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e8\u05e0\u05dc \u05d5\u05d1\u05dc\u05d5\u05e0\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u0930\u0947\u0928\u0947\u0932 \u0914\u0930 \u092c\u0947\u0932\u094b\u0928\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
@@ -81,6 +90,9 @@
     ],
     "name:hun_x_preferred":[
         "Rennell and Bellona"
+    ],
+    "name:hyw_x_preferred":[
+        "\u054c\u0565\u0576\u0565\u056c \u0565\u0582 \u054a\u0565\u056c\u0578\u0576\u0561 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Rennell dan Bellona"
@@ -100,6 +112,9 @@
     "name:kor_x_preferred":[
         "\ub80c\ub12c\ubca8\ub85c\ub098 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub80c\ub12c\ubca8\ub85c\ub098\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Renelas un Belonas province"
     ],
@@ -111,6 +126,9 @@
     ],
     "name:msa_x_preferred":[
         "Rennell and Bellona Province"
+    ],
+    "name:nan_x_preferred":[
+        "Rennell kap Bellona S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Rennell-Bellona"
@@ -275,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495724,
+    "wof:lastmodified":1690860388,
     "wof:name":"Rennell and Bellona",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/85/85677085.geojson
+++ b/data/856/770/85/85677085.geojson
@@ -44,6 +44,9 @@
     "name:ceb_x_preferred":[
         "Central Province"
     ],
+    "name:ces_x_preferred":[
+        "Centr\u00e1ln\u00ed provincie"
+    ],
     "name:dan_x_preferred":[
         "Central Province"
     ],
@@ -101,6 +104,9 @@
     "name:hye_x_preferred":[
         "\u053f\u0565\u0576\u057f\u0580\u0578\u0576\u0561\u056f\u0561\u0576 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
+    "name:hyw_x_preferred":[
+        "\u053f\u0565\u0564\u0580\u0578\u0576\u0561\u056f\u0561\u0576 \u0576\u0561\u0570\u0561\u0576\u0563"
+    ],
     "name:ind_x_preferred":[
         "Provinsi Tengah"
     ],
@@ -136,6 +142,9 @@
     ],
     "name:msa_x_preferred":[
         "Central Province"
+    ],
+    "name:nan_x_preferred":[
+        "Tiong-p\u014d\u0358 S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Central"
@@ -314,7 +323,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495725,
+    "wof:lastmodified":1690860389,
     "wof:name":"Central",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/89/85677089.geojson
+++ b/data/856/770/89/85677089.geojson
@@ -65,11 +65,17 @@
     "name:fra_x_variant":[
         "province de Guadalcanal"
     ],
+    "name:frr_x_preferred":[
+        "Guadalcanal"
+    ],
     "name:glg_x_preferred":[
         "Provincia de Guadalcanal"
     ],
     "name:guj_x_preferred":[
         "\u0a97\u0ac1\u0a86\u0aa1\u0abe\u0ab2\u0a95\u0ac7\u0aa8\u0abe\u0ab2 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d2\u05d5\u05d5\u05d3\u05dc\u05e7\u05e0\u05dc"
     ],
     "name:hin_x_preferred":[
         "\u0917\u0941\u0906\u0921\u093e\u0932\u0915\u0948\u0928\u0932"
@@ -82,6 +88,9 @@
     ],
     "name:hun_x_preferred":[
         "Guadalcanal"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053f\u0578\u0582\u0561\u0576\u057f\u0561\u056c\u0584\u0561\u0576\u0561\u056c \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Guadalcanal"
@@ -101,6 +110,9 @@
     "name:kor_x_preferred":[
         "\uacfc\ub2ec\uce74\ub0a0 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uacfc\ub2ec\uce74\ub0a0\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Gvadalkan\u0101la province"
     ],
@@ -112,6 +124,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Guadalcanal"
+    ],
+    "name:nan_x_preferred":[
+        "Guadalcanal S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Guadalcanal"
@@ -284,7 +299,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495724,
+    "wof:lastmodified":1690860388,
     "wof:name":"Guadalcanal",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/95/85677095.geojson
+++ b/data/856/770/95/85677095.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Isabel Province"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Isabel"
+    ],
     "name:dan_x_preferred":[
         "Isabel Province"
     ],
@@ -68,6 +71,9 @@
     "name:fra_x_variant":[
         "province d'Isabel"
     ],
+    "name:frr_x_preferred":[
+        "Isabel"
+    ],
     "name:glg_x_preferred":[
         "Isabel"
     ],
@@ -77,6 +83,9 @@
     "name:heb_x_preferred":[
         "\u05d0\u05d9\u05d6\u05d1\u05dc"
     ],
+    "name:heb_x_variant":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d0\u05d9\u05d6\u05d1\u05dc"
+    ],
     "name:hin_x_preferred":[
         "\u0907\u0938\u093e\u092c\u0947\u0932 \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
@@ -85,6 +94,9 @@
     ],
     "name:hun_x_preferred":[
         "Isabel"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053b\u0566\u0561\u057a\u0565\u056c \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Isabel"
@@ -104,6 +116,9 @@
     "name:kor_x_preferred":[
         "\uc774\uc0ac\ubca8 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc774\uc0ac\ubca8\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Isabelas province"
     ],
@@ -115,6 +130,9 @@
     ],
     "name:msa_x_preferred":[
         "Wilayah Isabel"
+    ],
+    "name:nan_x_preferred":[
+        "Isabel S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Isabel"
@@ -282,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495724,
+    "wof:lastmodified":1690860388,
     "wof:name":"Isabel",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/99/85677099.geojson
+++ b/data/856/770/99/85677099.geojson
@@ -38,6 +38,9 @@
     "name:ceb_x_preferred":[
         "Temotu Province"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Temotu"
+    ],
     "name:dan_x_preferred":[
         "Temotu Province"
     ],
@@ -53,6 +56,9 @@
     "name:eng_x_variant":[
         "Temotu Province"
     ],
+    "name:eus_x_preferred":[
+        "Temotu probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u062a\u0645\u0648\u062a\u0648"
     ],
@@ -65,11 +71,17 @@
     "name:fra_x_variant":[
         "province de Temotu"
     ],
+    "name:frr_x_preferred":[
+        "Temotu"
+    ],
     "name:glg_x_preferred":[
         "Temotu"
     ],
     "name:guj_x_preferred":[
         "\u0a9f\u0ac7\u0aae\u0acb\u0a9f\u0ac1 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d8\u05de\u05d5\u05d8\u05d5"
     ],
     "name:hin_x_preferred":[
         "\u091f\u0947\u092e\u094b\u091f\u0942 \u092a\u094d\u0930\u093e\u0902\u0924"
@@ -79,6 +91,9 @@
     ],
     "name:hun_x_preferred":[
         "Temotu"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0539\u0565\u0574\u0578\u0569\u0578\u0582 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Temotu"
@@ -98,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ud14c\ubaa8\ud22c \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ud14c\ubaa8\ud22c\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Temotu province"
     ],
@@ -109,6 +127,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Temotu"
+    ],
+    "name:nan_x_preferred":[
+        "Temotu S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Temotu"
@@ -281,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495724,
+    "wof:lastmodified":1690860388,
     "wof:name":"Temotu",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/03/85677103.geojson
+++ b/data/856/771/03/85677103.geojson
@@ -74,6 +74,9 @@
     "name:fra_x_preferred":[
         "Province occidentale"
     ],
+    "name:frr_x_preferred":[
+        "Western"
+    ],
     "name:glg_x_preferred":[
         "Occidental"
     ],
@@ -85,6 +88,9 @@
     ],
     "name:hrv_x_preferred":[
         "Zapadna provincija"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0531\u0580\u0565\u0582\u0574\u057f\u0565\u0561\u0576 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Barat"
@@ -118,6 +124,9 @@
     ],
     "name:msa_x_preferred":[
         "Western Province"
+    ],
+    "name:nan_x_preferred":[
+        "Sai-p\u014d\u0358 S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Western"
@@ -300,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495723,
+    "wof:lastmodified":1690860387,
     "wof:name":"Western",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/09/85677109.geojson
+++ b/data/856/771/09/85677109.geojson
@@ -59,6 +59,9 @@
     "name:fra_x_variant":[
         "province de Makira-Ulawa"
     ],
+    "name:frr_x_preferred":[
+        "Makira-Ulawa"
+    ],
     "name:glg_x_preferred":[
         "Makira"
     ],
@@ -73,6 +76,9 @@
     ],
     "name:hun_x_preferred":[
         "Makira"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0544\u0561\u0584\u056b\u0580\u0561 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Makira-Ulawa"
@@ -89,11 +95,17 @@
     "name:kor_x_preferred":[
         "\ub9c8\ud0a4\ub77c\uc6b8\ub77c\uc640 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub9c8\ud0a4\ub77c\uc6b8\ub77c\uc640\uc8fc"
+    ],
     "name:lit_x_preferred":[
         "Makiros-Ulavos provincija"
     ],
     "name:mrj_x_preferred":[
         "\u041c\u0430\u043a\u0438\u0440\u0430-\u0423\u043b\u0430\u0432\u0430"
+    ],
+    "name:nan_x_preferred":[
+        "Makira-Ulawa S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Makira"
@@ -252,7 +264,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495724,
+    "wof:lastmodified":1690860387,
     "wof:name":"Makira",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/15/85677115.geojson
+++ b/data/856/771/15/85677115.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.002495,
     "geom:area_square_m":30428599.41218,
-    "geom:bbox":"159.939707879,-9.46744483761,160.042043166,-9.42213307098",
-    "geom:latitude":-9.445012,
-    "geom:longitude":159.999341,
+    "geom:bbox":"159.939708,-9.467445,160.042043,-9.422133",
+    "geom:latitude":-9.445013,
+    "geom:longitude":159.999342,
     "iso:country":"SB",
     "label:eng_x_preferred_longname":[
         "Capital Territory (Honiara) Town Council"
@@ -61,17 +61,26 @@
     "name:fra_x_preferred":[
         "province de Guadalcanal"
     ],
+    "name:frr_x_preferred":[
+        "Guadalcanal"
+    ],
     "name:glg_x_preferred":[
         "Provincia de Guadalcanal"
     ],
     "name:guj_x_preferred":[
         "\u0a97\u0ac1\u0a86\u0aa1\u0abe\u0ab2\u0a95\u0ac7\u0aa8\u0abe\u0ab2 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d2\u05d5\u05d5\u05d3\u05dc\u05e7\u05e0\u05dc"
+    ],
     "name:hin_x_preferred":[
         "\u0917\u0941\u090f\u0921\u0932\u0915\u0948\u0928\u093e\u0932 \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
     "name:hrv_x_preferred":[
         "Guadalcanal"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053f\u0578\u0582\u0561\u0576\u057f\u0561\u056c\u0584\u0561\u0576\u0561\u056c \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Provinsi Guadalcanal"
@@ -91,6 +100,9 @@
     "name:kor_x_preferred":[
         "\uacfc\ub2ec\uce74\ub0a0 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uacfc\ub2ec\uce74\ub0a0\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Gvadalkan\u0101la province"
     ],
@@ -102,6 +114,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Guadalcanal"
+    ],
+    "name:nan_x_preferred":[
+        "Guadalcanal S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Guadalcanal"
@@ -120,6 +135,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0d9c\u0dd4\u0d86\u0da9\u0dbd\u0dca\u0d9a\u0dd0\u0db1\u0dbd\u0dca \u0db4\u0dc5\u0dcf\u0dad"
+    ],
+    "name:sin_x_variant":[
+        "\u0d9c\u0dd4\u0d86\u0da9\u0dbd\u0dca\u0d9a\u0dd0\u0db1\u0dbd\u0dca  \u0db4\u0dc5\u0dcf\u0dad"
     ],
     "name:spa_x_preferred":[
         "Guadalcanal"
@@ -256,7 +274,7 @@
         "wd:id":"Q760888"
     },
     "wof:country":"SB",
-    "wof:geomhash":"31a69dae2e5704b8baa458694fa1605c",
+    "wof:geomhash":"0de3a175dfd26486e798b5fbf9501efa",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -271,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638660,
+    "wof:lastmodified":1690860387,
     "wof:name":"Capital Territory (Honiara)",
     "wof:parent_id":85632591,
     "wof:placetype":"region",
@@ -286,10 +304,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    159.9397078794152,
-    -9.46744483760909,
-    160.04204316585947,
-    -9.42213307098439
+    159.939708,
+    -9.467445,
+    160.042043,
+    -9.422133
 ],
-  "geometry": {"coordinates":[[[159.93970787941521,-9.43287525788679],[159.96094811336479,-9.43466562282021],[159.99984785229663,-9.43328215884452],[160.01026451879261,-9.43181731611622],[160.01978600372115,-9.42766692508849],[160.02800540522537,-9.42213307098439],[160.04204316585947,-9.43114316902199],[160.0365056227364,-9.45052456815426],[160.03712090560532,-9.46159965350114],[160.02204648385816,-9.46744483760909],[160.01281724531964,-9.45790795898506],[159.98214653063792,-9.46115907383216],[159.95382414277003,-9.45031220224627],[159.93970787941521,-9.43287525788679]]],"type":"Polygon"}
+  "geometry": {"coordinates":[[[159.939708,-9.432875],[159.960948,-9.434666],[159.99984799999999,-9.433282],[160.010265,-9.431817],[160.01978600000001,-9.427667],[160.02800500000001,-9.422133],[160.04204300000001,-9.431143],[160.036506,-9.450525],[160.03712100000001,-9.4616],[160.02204599999999,-9.467445],[160.01281700000001,-9.457908],[159.982147,-9.461159],[159.953824,-9.450312],[159.939708,-9.432875]]],"type":"Polygon"}
 }

--- a/data/890/428/963/890428963.geojson
+++ b/data/890/428/963/890428963.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0644\u0627\u062a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u062a\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09a4\u09be"
     ],
@@ -128,7 +131,7 @@
         "\u0bb2\u0b9f\u0bbe"
     ],
     "name:tam_x_variant":[
-        "\u0bb2\u0b9f\u0bbe"
+        "\u0bb2\u0b9f\u0bbe "
     ],
     "name:tel_x_preferred":[
         "\u0c32\u0c24\u0c3e"
@@ -281,7 +284,7 @@
         }
     ],
     "wof:id":890428963,
-    "wof:lastmodified":1636495726,
+    "wof:lastmodified":1690860392,
     "wof:name":"Lata",
     "wof:parent_id":85677099,
     "wof:placetype":"locality",

--- a/data/890/444/217/890444217.geojson
+++ b/data/890/444/217/890444217.geojson
@@ -30,6 +30,12 @@
     "name:ara_x_preferred":[
         "\u0647\u0648\u0646\u064a\u0627\u0631\u0627"
     ],
+    "name:ary_x_preferred":[
+        "\u0647\u0648\u0646\u064a\u0627\u0631\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u0647\u0648\u0646\u064a\u0627\u0631\u0627"
+    ],
     "name:ast_x_preferred":[
         "Honiara"
     ],
@@ -39,8 +45,14 @@
     "name:aze_x_preferred":[
         "Honiara"
     ],
+    "name:ban_x_preferred":[
+        "Honiara"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0425\u0430\u043d\u0456\u044f\u0440\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0425\u0430\u043d\u0456\u044f\u0440\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09b9\u09c1\u09a8\u09bf\u09af\u09bc\u09be\u09b0\u09be"
@@ -108,6 +120,9 @@
     "name:fra_x_preferred":[
         "Honiara"
     ],
+    "name:frr_x_preferred":[
+        "Honiara"
+    ],
     "name:fry_x_preferred":[
         "Honiara"
     ],
@@ -153,7 +168,13 @@
     "name:hye_x_preferred":[
         "\u0540\u0578\u0576\u056b\u0561\u0580\u0561"
     ],
+    "name:hyw_x_preferred":[
+        "\u0540\u0578\u0576\u056b\u0561\u0580\u0561"
+    ],
     "name:ido_x_preferred":[
+        "Honiara"
+    ],
+    "name:ina_x_preferred":[
         "Honiara"
     ],
     "name:ind_x_preferred":[
@@ -183,6 +204,9 @@
     "name:lav_x_preferred":[
         "Honiara"
     ],
+    "name:lij_x_preferred":[
+        "Honiara"
+    ],
     "name:lit_x_preferred":[
         "Honiara"
     ],
@@ -191,6 +215,9 @@
     ],
     "name:ltz_x_preferred":[
         "Honiara"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d39\u0d4b\u0d23\u0d3f\u0d2f\u0d31"
     ],
     "name:mar_x_preferred":[
         "\u0939\u094b\u0928\u093f\u092f\u093e\u0930\u093e"
@@ -202,6 +229,9 @@
         "Honiara"
     ],
     "name:msa_x_preferred":[
+        "Honiara"
+    ],
+    "name:nah_x_preferred":[
         "Honiara"
     ],
     "name:nan_x_preferred":[
@@ -240,6 +270,9 @@
     "name:por_x_preferred":[
         "Honiara"
     ],
+    "name:pus_x_preferred":[
+        "\u0647\u0648\u0646\u06cc\u0627\u0631\u0627"
+    ],
     "name:ron_x_preferred":[
         "Honiara"
     ],
@@ -270,6 +303,9 @@
     "name:spa_x_preferred":[
         "Honiara"
     ],
+    "name:srd_x_preferred":[
+        "Honiara"
+    ],
     "name:srp_x_preferred":[
         "\u0425\u043e\u043d\u0438\u0458\u0430\u0440\u0430"
     ],
@@ -293,6 +329,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c39\u0c4b\u0c28\u0c3f\u0c2f\u0c3e\u0c30\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0425\u043e\u043d\u0438\u0430\u0440\u0430"
     ],
     "name:tgl_x_preferred":[
         "Honiara"
@@ -326,6 +365,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u970d\u5c3c\u4e9e\u62c9"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10f0\u10dd\u10dc\u10d8\u10d0\u10e0\u10d0"
     ],
     "name:yor_x_preferred":[
         "Honiara"
@@ -470,7 +512,7 @@
         }
     ],
     "wof:id":890444217,
-    "wof:lastmodified":1607390902,
+    "wof:lastmodified":1690860393,
     "wof:name":"Honiara",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/444/219/890444219.geojson
+++ b/data/890/444/219/890444219.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062c\u064a\u0632\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u0632\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Gizo"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09bf\u099c\u09cb"
     ],
@@ -39,6 +45,9 @@
     ],
     "name:eng_x_preferred":[
         "Gizo"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u06cc\u0632\u0648"
     ],
     "name:fij_x_preferred":[
         "Gizo"
@@ -234,7 +243,7 @@
         }
     ],
     "wof:id":890444219,
-    "wof:lastmodified":1636495726,
+    "wof:lastmodified":1690860393,
     "wof:name":"Gizo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.