### PR TITLE
sb concordances, placetype local, and more

### DIFF
--- a/data/856/325/91/85632591.geojson
+++ b/data/856/325/91/85632591.geojson
@@ -1168,6 +1168,7 @@
         "hasc:id":"SB",
         "icao:code":"H4",
         "ioc:id":"SOL",
+        "iso:code":"SB",
         "itu:id":"SLM",
         "m49:code":"090",
         "marc:id":"bp",
@@ -1181,6 +1182,7 @@
         "wk:page":"Solomon Islands",
         "wmo:id":"SO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
     "wof:country_alpha3":"SLB",
     "wof:geom_alt":[
@@ -1201,7 +1203,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639512,
+    "wof:lastmodified":1695881166,
     "wof:name":"Solomon Islands",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/770/77/85677077.geojson
+++ b/data/856/770/77/85677077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.363449,
-    "geom:area_square_m":4438676672.005287,
+    "geom:area_square_m":4438674448.046347,
     "geom:bbox":"159.351573,-9.851007,162.757579,-5.00099",
     "geom:latitude":-8.999679,
     "geom:longitude":161.026716,
@@ -280,17 +280,19 @@
         "gn:id":2106552,
         "gp:id":2344836,
         "hasc:id":"SB.ML",
+        "iso:code":"SB-ML",
         "iso:id":"SB-ML",
         "qs_pg:id":453106,
         "unlc:id":"SB-ML",
         "wd:id":"Q1190896",
         "wk:page":"Malaita Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a29d05b46d25bf316528755680256d38",
+    "wof:geomhash":"c6ec437ca76fb4d07851fb4eb44c66e9",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860389,
+    "wof:lastmodified":1695884812,
     "wof:name":"Malaita",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/81/85677081.geojson
+++ b/data/856/770/81/85677081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055516,
-    "geom:area_square_m":672343797.205285,
+    "geom:area_square_m":672344615.759342,
     "geom:bbox":"159.777354,-11.84588,160.582205,-11.28281",
     "geom:latitude":-11.640074,
     "geom:longitude":160.250039,
@@ -273,12 +273,14 @@
         "gn:id":7280293,
         "gp:id":-2344841,
         "hasc:id":"SB.RB",
+        "iso:code":"SB-RB",
         "iso:id":"SB-RB",
         "unlc:id":"SB-RB",
         "wd:id":"Q1051475"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
-    "wof:geomhash":"e9b792710f1f9bd172540cc40c3fe09a",
+    "wof:geomhash":"e3cedde1e9f815fff536dba75acf51d7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860388,
+    "wof:lastmodified":1695884812,
     "wof:name":"Rennell and Bellona",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/85/85677085.geojson
+++ b/data/856/770/85/85677085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047225,
-    "geom:area_square_m":576637091.408152,
+    "geom:area_square_m":576636927.550286,
     "geom:bbox":"159.039317,-9.193048,160.414236,-8.873224",
     "geom:latitude":-9.074096,
     "geom:longitude":159.886279,
@@ -298,17 +298,19 @@
         "gn:id":2109495,
         "gp:id":2344838,
         "hasc:id":"SB.CN",
+        "iso:code":"SB-CE",
         "iso:id":"SB-CE",
         "qs_pg:id":1114930,
         "unlc:id":"SB-CE",
         "wd:id":"Q293722",
         "wk:page":"Central Province (Solomon Islands)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3943867eb0c34626503be239ddbd1144",
+    "wof:geomhash":"afdb0c6a3b006b68eba305ea4b0ea6bd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860389,
+    "wof:lastmodified":1695884812,
     "wof:name":"Central",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/89/85677089.geojson
+++ b/data/856/770/89/85677089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.437927,
-    "geom:area_square_m":5338833346.356157,
+    "geom:area_square_m":5338834218.023011,
     "geom:bbox":"159.592133,-9.937107,160.826345,-9.247735",
     "geom:latitude":-9.623621,
     "geom:longitude":160.171276,
@@ -277,14 +277,16 @@
         "gn:id":2108831,
         "gp:id":2344839,
         "hasc:id":"SB.GU",
+        "iso:code":"SB-GU",
         "iso:id":"SB-GU",
         "loc:id":"n90679466",
         "qs_pg:id":1114931,
         "wd:id":"Q760888",
         "wk:page":"Guadalcanal Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
-    "wof:geomhash":"d9eecddeadd0cccd2cb3d58531137144",
+    "wof:geomhash":"a7c3cd2bf6bbfd03294259a8958d256d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -299,7 +301,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860388,
+    "wof:lastmodified":1695884812,
     "wof:name":"Guadalcanal",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/95/85677095.geojson
+++ b/data/856/770/95/85677095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331526,
-    "geom:area_square_m":4059278924.385703,
+    "geom:area_square_m":4059279172.720395,
     "geom:bbox":"158.194347,-8.562433,159.900401,-7.390558",
     "geom:latitude":-8.01741,
     "geom:longitude":159.159152,
@@ -278,14 +278,16 @@
         "gn:id":2108262,
         "gp:id":2344840,
         "hasc:id":"SB.IS",
+        "iso:code":"SB-IS",
         "iso:id":"SB-IS",
         "qs_pg:id":1114939,
         "unlc:id":"SB-IS",
         "wd:id":"Q1139082",
         "wk:page":"Isabel Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
-    "wof:geomhash":"165c563d6f9bab24bef1e832589b0192",
+    "wof:geomhash":"b1fb5fea100876b7c34940711966a21a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860388,
+    "wof:lastmodified":1695884812,
     "wof:name":"Isabel",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/770/99/85677099.geojson
+++ b/data/856/770/99/85677099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073644,
-    "geom:area_square_m":893850197.310936,
+    "geom:area_square_m":893851031.388213,
     "geom:bbox":"165.722911,-12.290623,168.825857,-9.801853",
     "geom:latitude":-11.004665,
     "geom:longitude":166.263627,
@@ -277,17 +277,19 @@
         "gn:id":2178472,
         "gp:id":20069919,
         "hasc:id":"SB.TE",
+        "iso:code":"SB-TE",
         "iso:id":"SB-TE",
         "qs_pg:id":1188783,
         "unlc:id":"SB-TE",
         "wd:id":"Q936088",
         "wk:page":"Temotu Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27b9dd35a5d48502e07921eed756707c",
+    "wof:geomhash":"b34847378a9b7d7d9cfc877abfa62dfa",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -302,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860388,
+    "wof:lastmodified":1695884812,
     "wof:name":"Temotu",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/03/85677103.geojson
+++ b/data/856/771/03/85677103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.427403,
-    "geom:area_square_m":5231456504.776001,
+    "geom:area_square_m":5231457055.131014,
     "geom:bbox":"155.507986,-8.836847,158.256684,-6.774672",
     "geom:latitude":-8.145791,
     "geom:longitude":157.252322,
@@ -285,16 +285,18 @@
         "gn:id":2101556,
         "gp:id":2344837,
         "hasc:id":"SB.WE",
+        "iso:code":"SB-WE",
         "iso:id":"SB-WE",
         "qs_pg:id":1142806,
         "wd:id":"Q150325",
         "wk:page":"Western Province (Solomon Islands)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6597d1a88ab366200c8ef8cbdd4dee0c",
+    "wof:geomhash":"2d2db68fdfee7535e116a5f11a0cb9dc",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860387,
+    "wof:lastmodified":1695884812,
     "wof:name":"Western",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/05/85677105.geojson
+++ b/data/856/771/05/85677105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.245801,
-    "geom:area_square_m":3016444020.895017,
+    "geom:area_square_m":3016444568.901568,
     "geom:bbox":"156.446625,-7.474786,157.797374,-6.599867",
     "geom:latitude":-7.039331,
     "geom:longitude":156.974908,
@@ -207,12 +207,14 @@
         "gn:id":7280292,
         "gp:id":-2344837,
         "hasc:id":"SB.CH",
+        "iso:code":"SB-CH",
         "iso:id":"SB-CH",
         "unlc:id":"SB-CH",
         "wd:id":"Q230468"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
-    "wof:geomhash":"5355c9bb2469fee0d6674dd6355d3cb4",
+    "wof:geomhash":"8faca4d5dcbbdc35af1c2d941b444925",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -227,7 +229,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495724,
+    "wof:lastmodified":1695884812,
     "wof:name":"Choiseul",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/09/85677109.geojson
+++ b/data/856/771/09/85677109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.257684,
-    "geom:area_square_m":3132446272.813243,
+    "geom:area_square_m":3132446311.346888,
     "geom:bbox":"161.280772,-10.900323,162.489594,-10.200453",
     "geom:latitude":-10.549648,
     "geom:longitude":161.844932,
@@ -240,16 +240,18 @@
         "gn:id":2178730,
         "gp:id":2344841,
         "hasc:id":"SB.MK",
+        "iso:code":"SB-MK",
         "iso:id":"SB-MK",
         "qs_pg:id":191315,
         "wd:id":"Q1116700",
         "wk:page":"Makira-Ulawa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ebd1ce9ccd64db36bb2c0c01ead5a0c",
+    "wof:geomhash":"5ea92690632c850bec1297b8de2cf0c6",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -264,7 +266,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860387,
+    "wof:lastmodified":1695884812,
     "wof:name":"Makira",
     "wof:parent_id":85632591,
     "wof:placetype":"region",

--- a/data/856/771/15/85677115.geojson
+++ b/data/856/771/15/85677115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002495,
-    "geom:area_square_m":30428599.41218,
+    "geom:area_square_m":30428602.514698,
     "geom:bbox":"159.939708,-9.467445,160.042043,-9.422133",
     "geom:latitude":-9.445013,
     "geom:longitude":159.999342,
@@ -269,12 +269,14 @@
         "gn:id":-99,
         "gp:id":-2344839,
         "hasc:id":"SB.CT",
+        "iso:code":"SB-CT",
         "iso:id":"SB-CT",
         "unlc:id":"SB-CT",
         "wd:id":"Q760888"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SB",
-    "wof:geomhash":"0de3a175dfd26486e798b5fbf9501efa",
+    "wof:geomhash":"d84dbe0aa50835fecdd0602b3d11ddd8",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -289,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860387,
+    "wof:lastmodified":1695884326,
     "wof:name":"Capital Territory (Honiara)",
     "wof:parent_id":85632591,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.